### PR TITLE
Add pypy to Travis-CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ python:
     - "2.7"
     - "3.3"
     - "3.4"
+    - "pypy"
+    - "pypy3"
+
+matrix:
+    allow_failures:
+        - python: "pypy"
+        - python: "pypy3"
 
 install:
     - "python setup.py install"


### PR DESCRIPTION
I'd be nice to support pypy in bpython at some point. Let's start by running the test suite for curtsies for pypy and pypy3.