### PR TITLE
Added support for the shorthand ESC[m, which is equivalent to ESC[0m

### DIFF
--- a/curtsies/escseqparse.py
+++ b/curtsies/escseqparse.py
@@ -86,7 +86,9 @@ def token_type(info):
     """
     """
     if info['command'] == 'm':
-        value, = info['numbers']
+        # The default action for ESC[m is to act like ESC[0m
+        # Ref: https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_codes
+        value, = info['numbers'] if len(info['numbers']) else [0]
         if value in FG_NUMBER_TO_COLOR: return {'fg':FG_NUMBER_TO_COLOR[value]}
         if value in BG_NUMBER_TO_COLOR: return {'bg':BG_NUMBER_TO_COLOR[value]}
         if value in NUMBER_TO_STYLE: return {NUMBER_TO_STYLE[value]:True}


### PR DESCRIPTION
Many applications use the shorthand notation for resetting the foreground/background colors, which does not include a parameter. According to the [Wikipedia page][1], the `ESC[...m` command does not require any parameters:

> Sets SGR parameters, including text color. After CSI can be _zero_ or more parameters separated with ;. With no parameters, CSI m is treated as CSI 0 m (reset / normal), which is typical of most of the ANSI escape sequences.

[1]: https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_codes