### PR TITLE
Add Python3 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setup(name='curtsies',
           'License :: OSI Approved :: MIT License',
           'Operating System :: POSIX',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 3',
           ],
       zip_safe=False)


### PR DESCRIPTION
Motivated by caniusepython3[0] reporting curtsies doesn't support Python3.

```shell
$ caniusepython3 --projects curtsies
Finding and checking dependencies ...

You need 1 project to transition to Python 3.
Of that 1 project, 1 has no direct dependencies blocking its transition:

  curtsies
```

0: https://pypi.python.org/pypi/caniusepython3