### PR TITLE
Fix quadratic runtime of width_aware_slice

### DIFF
--- a/curtsies/formatstring.py
+++ b/curtsies/formatstring.py
@@ -523,7 +523,9 @@ def interval_overlap(a, b, x, y):
 
 
 def width_aware_slice(s, start, end, replacement_char=u' '):
-    divides = [wcwidth.wcswidth(s, i) for i in range(len(s)+1)]
+    divides = [0]
+    for c in s:
+        divides.append(divides[-1] + wcwidth.wcswidth(c))
 
     new_chunk_chars = []
     for char, char_start, char_end in zip(s, divides[:-1], divides[1:]):


### PR DESCRIPTION
Causes: https://github.com/bpython/bpython/issues/703

If the string-to-be-sliced is very long, the old code called `wcswidth` on all n many prefixes of the string, where n is the length in characters.  This means that `wcswidth` needs to measure the beginning of the string again and again, resulting in a quadratic runtime (because of Gaussian sum).  Example:

```
>>> t1 = n(); x = curtsies.formatstring.width_aware_slice("haaaaaallowooooorld" * 1, 5, 13); n() - t1
datetime.timedelta(0, 0, 455)
>>> t1 = n(); x = curtsies.formatstring.width_aware_slice("haaaaaallowooooorld" * 10, 5, 13); n() - t1
datetime.timedelta(0, 0, 32304)
>>> t1 = n(); x = curtsies.formatstring.width_aware_slice("haaaaaallowooooorld" * 100, 5, 13); n() - t1
datetime.timedelta(0, 2, 798822)
```

As you can see, a tenfold string length used to mean roughly hundredfold running time.

This patch reduces the running time down to linear.